### PR TITLE
Fix 'missing mkdirp' Error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "stable"
+  - "9.4.0"
 services:
   - postgresql
 before_script:

--- a/app/client/components/home-page/HomePage.jsx
+++ b/app/client/components/home-page/HomePage.jsx
@@ -91,7 +91,6 @@ export class HomePage extends React.Component {
                   <div className="col s12 m10 offset-m1 center">
                     <header className="index-header">
                       <h2 className="light"><b>Welcome to PostIT!</b></h2>
-                      <p className="light"><b>Hosted on AWS.</b></p>
                     </header>
                     <div className="auth">
                       <h4 className="index-line-height">


### PR DESCRIPTION
### What does this PR do?

The current stable version of node (`v11.2.0`) throws an error on travis, `Error: Cannot find module 'mkdirp'`. This PR updates the node version specified in the travis config file (formerly stable) to `v9.4.0`.

<img width="1307" alt="screen shot 2018-11-25 at 8 55 34 pm" src="https://user-images.githubusercontent.com/15054956/48983985-3fee4100-f0f6-11e8-90b3-a791c8a5eba7.png">
